### PR TITLE
docker compose and type sense conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+search-engine/data/*
+!search-engine/data/.gitkeep

--- a/search-engine/docker-compose.yml
+++ b/search-engine/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  typesense:
+    image: typesense/typesense:26.0
+    restart: on-failure
+    ports:
+      - "8108:8108"
+    volumes:
+      - ./data:/data
+      - ./typesense-server.ini:/etc/typesense/typesense-server.ini
+    command: typesense-server --config=/etc/typesense/typesense-server.ini

--- a/search-engine/typesense-server.ini
+++ b/search-engine/typesense-server.ini
@@ -1,0 +1,5 @@
+[server]
+
+api-key = xyz
+data-dir = /data
+api-port = 8108


### PR DESCRIPTION
### Pull Request Overview

This PR introduces configuration files for deploying a Typesense service in a Docker environment. It includes updates to `.gitignore` to manage the new data directory effectively and adds necessary Docker and configuration files for Typesense.

### Changes

- **.gitignore**: Updated to exclude `search-engine/data/*` while keeping `.gitkeep`.
- **search-engine/data/.gitkeep**: Added to track the empty `data` directory in Git.
- **search-engine/docker-compose.yml**: New file to configure Docker container for Typesense.
- **search-engine/typesense-server.ini**: Contains Typesense configurations such as API key and ports.

### How to Run

Run the Typesense container with:
```bash
cd search-engine
docker compose up
```

Ensure Docker is installed and operational before running the command.