### PR TITLE
Update dependabot to ignore eslint 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
     directory: "/frontend" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "eslint"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,7 +32,7 @@
     "@types/node": "^20.12.10",
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "eslint": "^9.2.0",
+    "eslint": "^8.57.0",
     "eslint-config-next": "14.2.3",
     "eslint-plugin-react": "^7.34.1",
     "globals": "^15.1.0",


### PR DESCRIPTION
Updated settings for dependabot to prevent eslint weekly update since the upgrade to 9.2.0 will break some of the libraries.
