### PR TITLE
Call and format API data.

### DIFF
--- a/frontend/app/api/quickbooks/find_account/route.ts
+++ b/frontend/app/api/quickbooks/find_account/route.ts
@@ -1,0 +1,58 @@
+import { options } from "@/app/api/auth/[...nextauth]/options";
+import { getServerSession } from "next-auth";
+const QB = require('node-quickbooks');
+
+export async function GET() {
+    const session = await getServerSession(options);
+    
+    const oauthToken = session?.accessToken;
+    const realmId = session?.realmId;
+    const refreshToken = session?.refreshToken;
+
+    // Try to get the account and catch any errors.
+    try {
+        
+        // Create the QuickBooks object.
+        const qbo = new QB(
+            process.env.CLIENT_ID,
+            process.env.CLIENT_SECRET,
+            oauthToken,
+            false,
+            realmId,
+            true,
+            true,
+            null,
+            '2.0',
+            refreshToken,
+        );
+
+        // Define the ID of the account to get.
+        let ID = '7';
+
+        // Get the account.
+        const resp: any = await new Promise((resolve, reject) => {
+            qbo.getAccount(ID, (err: Error, data: any) => {
+                if (err) {
+                    reject(err);
+                }
+                resolve(data);
+            });
+        });
+
+        // Get response as result and remove unnecessary fields.
+        const results = resp
+        delete results.FullyQualifiedName;
+        delete results.CurrentBalance;
+        delete results.CurrentBalanceWithSubAccounts;
+        delete results.CurrencyRef;
+        delete results.domain;
+        delete results.SyncToken;
+        delete results.MetaData;
+        
+        // Show results.
+        return Response.json(results);
+    } catch (error) {
+        // Show the caught error.
+        return Response.error();
+    }
+}

--- a/frontend/app/api/quickbooks/find_account/route.ts
+++ b/frontend/app/api/quickbooks/find_account/route.ts
@@ -26,7 +26,7 @@ export async function GET() {
             refreshToken,
         );
 
-        // Define the ID of the account to get (Change for searching).
+        // Define the ID of the account to get (Change this variable to search by ID).
         let ID = '0';
 
         // Search for an account with the matching ID.

--- a/frontend/app/api/quickbooks/find_account/route.ts
+++ b/frontend/app/api/quickbooks/find_account/route.ts
@@ -9,7 +9,7 @@ export async function GET() {
     const realmId = session?.realmId;
     const refreshToken = session?.refreshToken;
 
-    // Try to get the account and catch any errors.
+    // Try to get a specific account and catch any errors.
     try {
         
         // Create the QuickBooks object.

--- a/frontend/app/api/quickbooks/find_account/route.ts
+++ b/frontend/app/api/quickbooks/find_account/route.ts
@@ -26,11 +26,11 @@ export async function GET() {
             refreshToken,
         );
 
-        // Define the ID of the account to get.
-        let ID = '7';
+        // Define the ID of the account to get (Change for searching).
+        let ID = '0';
 
-        // Get the account.
-        const resp: any = await new Promise((resolve, reject) => {
+        // Search for an account with the matching ID.
+        const response: any = await new Promise((resolve, reject) => {
             qbo.getAccount(ID, (err: Error, data: any) => {
                 if (err) {
                     reject(err);
@@ -40,7 +40,7 @@ export async function GET() {
         });
 
         // Get response as result and remove unnecessary fields.
-        const results = resp
+        const results = response;
         delete results.FullyQualifiedName;
         delete results.CurrentBalance;
         delete results.CurrentBalanceWithSubAccounts;

--- a/frontend/app/api/quickbooks/find_purchase/route.ts
+++ b/frontend/app/api/quickbooks/find_purchase/route.ts
@@ -1,0 +1,70 @@
+import { options } from "@/app/api/auth/[...nextauth]/options";
+import { getServerSession } from "next-auth";
+const QB = require('node-quickbooks');
+
+export async function GET() {
+    const session = await getServerSession(options);
+    
+    const oauthToken = session?.accessToken;
+    const realmId = session?.realmId;
+    const refreshToken = session?.refreshToken;
+
+    // Try to get the purchase object and catch any errors.
+    try {
+        
+        // Create the QuickBooks object.
+        const qbo = new QB(
+            process.env.CLIENT_ID,
+            process.env.CLIENT_SECRET,
+            oauthToken,
+            false,
+            realmId,
+            true,
+            true,
+            null,
+            '2.0',
+            refreshToken,
+        );
+
+        // Define the ID of the purchase object to get (Change for searching).
+        let ID = '57';
+
+        // Search for a purchase object with the matching ID.
+        const response: any = await new Promise((resolve, reject) => {
+            qbo.getPurchase(ID, (err: Error, data: any) => {
+                if (err) {
+                    reject(err);
+                }
+                resolve(data);
+            });
+        });
+
+        // Get response as result and create a formatted dictionary necessary fields.
+        const results = response;
+        let formatted_result = {
+            id: results.Id,
+            purchase_type: results.PaymentType,
+            date: results.TxnDate,
+            total: results.TotalAmt,
+            primary_account: results.AccountRef.name,
+            purchase_name: results.EntityRef.name,
+            purchase_category: null,
+        }
+
+        // Check each element in the line for the specific line that contains the categorizing account.
+        for (let i = 0; i < results.Line.length; i++) {
+            if (results.Line[i].DetailType === 'AccountBasedExpenseLineDetail') {
+                // If it is present, update the purchase category field of the formatted results.
+                formatted_result.purchase_category = results.Line[i].AccountBasedExpenseLineDetail.AccountRef.name;
+                break;
+            }
+        }
+
+        
+        // Show results.
+        return Response.json(formatted_result);
+    } catch (error) {
+        // Show the caught error.
+        return Response.error();
+    }
+}

--- a/frontend/app/api/quickbooks/find_purchase/route.ts
+++ b/frontend/app/api/quickbooks/find_purchase/route.ts
@@ -26,7 +26,7 @@ export async function GET() {
             refreshToken,
         );
 
-        // Define the ID of the purchase object to get (Change for searching).
+        // Define the ID of the purchase object to get (Change this variable to search by ID).
         let ID = '57';
 
         // Search for a purchase object with the matching ID.

--- a/frontend/app/api/quickbooks/get_accounts/route.ts
+++ b/frontend/app/api/quickbooks/get_accounts/route.ts
@@ -25,9 +25,9 @@ export async function GET() {
             refreshToken,
         );
 
-        // Get the expense accounts.
-        const resp: any = await new Promise((resolve, reject) => {
-            qbo.findAccounts({Classification: 'Expense'}, (err: Error, data: any) => {
+        // Get the expense accounts by searching by their classification. Returns a limit of 1000 accounts.
+        const response: any = await new Promise((resolve, reject) => {
+            qbo.findAccounts({Classification: 'Expense', limit: 1000}, (err: Error, data: any) => {
                 if (err) {
                     reject(err);
                 }
@@ -36,7 +36,7 @@ export async function GET() {
         });
 
         // Get response as result array.
-        const results = resp.QueryResponse.Account
+        const results = response.QueryResponse.Account;
 
         // For each account object, remove unnecessary fields and delete any inactive accounts.
         for (let account = 0; account < results.length; account++) {
@@ -61,6 +61,11 @@ export async function GET() {
             delete results[account].SyncToken;
             delete results[account].MetaData;
         }
+
+        // Preform any additional filtering here.
+        // ***************************************
+
+        // ***************************************
         
         // Show results.
         return Response.json(results);

--- a/frontend/app/api/quickbooks/get_accounts/route.ts
+++ b/frontend/app/api/quickbooks/get_accounts/route.ts
@@ -1,0 +1,71 @@
+import { options } from "@/app/api/auth/[...nextauth]/options";
+import { getServerSession } from "next-auth";
+const QB = require('node-quickbooks');
+
+export async function GET() {
+    const session = await getServerSession(options);
+    
+    const oauthToken = session?.accessToken;
+    const realmId = session?.realmId;
+    const refreshToken = session?.refreshToken;
+
+    // Try to get all expense accounts and catch any errors.
+    try {
+        // Create the QuickBooks object.
+        const qbo = new QB(
+            process.env.CLIENT_ID,
+            process.env.CLIENT_SECRET,
+            oauthToken,
+            false,
+            realmId,
+            true,
+            true,
+            null,
+            '2.0',
+            refreshToken,
+        );
+
+        // Get the expense accounts.
+        const resp: any = await new Promise((resolve, reject) => {
+            qbo.findAccounts({Classification: 'Expense'}, (err: Error, data: any) => {
+                if (err) {
+                    reject(err);
+                }
+                resolve(data);
+            });
+        });
+
+        // Get response as result array.
+        const results = resp.QueryResponse.Account
+
+        // For each account object, remove unnecessary fields and delete any inactive accounts.
+        for (let account = 0; account < results.length; account++) {
+            // Delete any inactive accounts.
+            if (!results[account].Active) {
+                // Splice out the inactive account.
+                results.splice(account, 1);
+                // Decrement the account index, because the splice moved each remaining account back one index.
+                // Skip for last account: no remaining accounts to check.
+                if (account !== results.length - 1){
+                    account--;
+                }
+                // Skip to next account.
+                continue;
+            }
+            // Delete accounts remain as nulls.
+            delete results[account].FullyQualifiedName;
+            delete results[account].CurrentBalance;
+            delete results[account].CurrentBalanceWithSubAccounts;
+            delete results[account].CurrencyRef;
+            delete results[account].domain;
+            delete results[account].SyncToken;
+            delete results[account].MetaData;
+        }
+        
+        // Show results.
+        return Response.json(results);
+    } catch (error) {
+        // Show the caught error.
+        return Response.error();
+    }
+}

--- a/frontend/app/api/quickbooks/get_accounts/route.ts
+++ b/frontend/app/api/quickbooks/get_accounts/route.ts
@@ -60,6 +60,7 @@ export async function GET() {
             delete results[account].domain;
             delete results[account].SyncToken;
             delete results[account].MetaData;
+            delete results[account].sparse;
         }
 
         // Preform any additional filtering here.

--- a/frontend/app/api/quickbooks/get_transactions/route.ts
+++ b/frontend/app/api/quickbooks/get_transactions/route.ts
@@ -63,6 +63,7 @@ export async function GET() {
                 let formatted_result = {
                     date: results[account].ColData[0].value,
                     transaction_type: results[account].ColData[1].value,
+                    transaction_ID: results[account].ColData[1].id,
                     name: results[account].ColData[2].value,
                     account: results[account].ColData[3].value,
                     category: results[account].ColData[4].value,

--- a/frontend/app/api/quickbooks/get_transactions/route.ts
+++ b/frontend/app/api/quickbooks/get_transactions/route.ts
@@ -9,7 +9,7 @@ export async function GET() {
     const realmId = session?.realmId;
     const refreshToken = session?.refreshToken;
 
-    // Try to get all expense accounts and catch any errors.
+    // Try to get all transactions we care about in a set time period and catch any errors.
     try {
         // Create the QuickBooks object.
         const qbo = new QB(

--- a/frontend/app/api/quickbooks/get_transactions/route.ts
+++ b/frontend/app/api/quickbooks/get_transactions/route.ts
@@ -1,0 +1,86 @@
+import { options } from "@/app/api/auth/[...nextauth]/options";
+import { getServerSession } from "next-auth";
+const QB = require('node-quickbooks');
+
+export async function GET() {
+    const session = await getServerSession(options);
+    
+    const oauthToken = session?.accessToken;
+    const realmId = session?.realmId;
+    const refreshToken = session?.refreshToken;
+
+    // Try to get all expense accounts and catch any errors.
+    try {
+        // Create the QuickBooks object.
+        const qbo = new QB(
+            process.env.CLIENT_ID,
+            process.env.CLIENT_SECRET,
+            oauthToken,
+            false,
+            realmId,
+            true,
+            true,
+            null,
+            '2.0',
+            refreshToken,
+        );
+
+        // Define the parameters for the report. 
+        // Defines a start and end date as well as what columns to include for each report.
+        let parameters = {start_date: '2022-01-01', end_date: '2024-12-31', limit: 1000, columns: ['account_name', 'name', 'other_account', 'tx_date', 'txn_type', 'subt_nat_amount']};
+        // Get the expense accounts.
+        const response: any = await new Promise((resolve, reject) => {
+            qbo.reportTransactionList(parameters, (err: Error, data: any) => {
+                if (err) {
+                    reject(err);
+                }
+                resolve(data);
+            });
+        });
+
+        // Get response as result array.
+        const results = response.Rows.Row;
+        const formatted_results = [];
+
+        // Define valid transaction types.
+        let purchase_transactions = ["Check", "Cash Expense", "Credit Card Expense"]
+
+        // For each account object, remove unnecessary fields and delete any inactive accounts.
+        for (let account = 0; account < results.length; account++) {
+            // Delete any inactive accounts.
+            if (!purchase_transactions.includes(results[account].ColData[1].value)) {
+                // Splice out the inactive account.
+                results.splice(account, 1);
+                // Decrement the account index, because the splice moved each remaining account back one index.
+                // Skip for last account: no remaining accounts to check.
+                if (account !== results.length - 1) {
+                    account--;
+                }
+                // Skip to next account.
+                continue;
+            } else {
+                // Create a formatted result object for an individual transaction.
+                let formatted_result = {
+                    date: results[account].ColData[0].value,
+                    transaction_type: results[account].ColData[1].value,
+                    name: results[account].ColData[2].value,
+                    account: results[account].ColData[3].value,
+                    category: results[account].ColData[4].value,
+                    amount: results[account].ColData[5].value
+                }
+                formatted_results.push(formatted_result);
+            }
+        }
+
+        // Preform any additional filtering here.
+        // ***************************************
+        
+        // ***************************************
+        
+        // Show formatted results.
+        return Response.json(formatted_results);
+    } catch (error) {
+        // Show the caught error.
+        return Response.error();
+    }
+}

--- a/frontend/app/api/quickbooks/update_purchase/route.ts
+++ b/frontend/app/api/quickbooks/update_purchase/route.ts
@@ -1,0 +1,77 @@
+import { options } from "@/app/api/auth/[...nextauth]/options";
+import { getServerSession } from "next-auth";
+const QB = require('node-quickbooks');
+
+export async function GET() {
+    // ***NOTE*** Currently makes a POST request in addition to a GET request.
+    // Eventually the find_purchase route should get the purchase object and pass it to this route.
+    // This route should then be changed to a POST function with only one API call.
+    const session = await getServerSession(options);
+    
+    const oauthToken = session?.accessToken;
+    const realmId = session?.realmId;
+    const refreshToken = session?.refreshToken;
+
+    // Try to get a purchase object update it while catching any errors.
+    try {
+        
+        // Create the QuickBooks object.
+        const qbo = new QB(
+            process.env.CLIENT_ID,
+            process.env.CLIENT_SECRET,
+            oauthToken,
+            false,
+            realmId,
+            true,
+            true,
+            null,
+            '2.0',
+            refreshToken,
+        );
+
+        // Define the ID of the purchase object to get (Change this variable to search by ID).
+        let ID = '57';
+        // Define the name and ID of the new account to categorize the purchase object.
+        let account_name = 'Automobile';
+        let account_id = '55';
+
+        // Search for a purchase object with the matching ID.
+        const response: any = await new Promise((resolve, reject) => {
+            qbo.getPurchase(ID, (err: Error, data: any) => {
+                if (err) {
+                    reject(err);
+                }
+                resolve(data);
+            });
+        });
+
+        // Get response as result and create a formatted dictionary necessary fields.
+        const results = response;
+        
+        // Check each element in the line for the specific line that contains the categorizing account.
+        for (let i = 0; i < results.Line.length; i++) {
+            if (results.Line[i].DetailType === 'AccountBasedExpenseLineDetail') {
+                // If it is present, update the purchase category field of the formatted results.
+                results.Line[i].AccountBasedExpenseLineDetail.AccountRef.value = account_id;
+                results.Line[i].AccountBasedExpenseLineDetail.AccountRef.name = account_name;
+                break;
+            }
+        }
+
+        // Update the purchase object with the updated results value.
+        const update_response: any = await new Promise((resolve, reject) => {
+            qbo.updatePurchase(results, (err: Error, data: any) => {
+                if (err) {
+                    reject(err);
+                }
+                resolve(data);
+            });
+        });
+
+        // Show results.
+        return Response.json(results);
+    } catch (error) {
+        // Show the caught error.
+        return Response.error();
+    }
+}


### PR DESCRIPTION
Created 5 API call endpoints that call different data types and work to format them for convenient use.

- Get_Accounts: Gets all expense accounts (limit of 1000) within a certain time frame. Testing time is start of 2022 to end of 2024. Formats the data it returns to easy to use dictionaries.

- Find_Account: Gets one individual account by its ID and formats it the same as Get_Accounts. This is primarily for testing and has no practical application in the app.

- Get_Transactions: Calls all transactions and within the 2022 - 2024 date range (limit of 1000). Specifies what columns to call for the report, filters to just expense transactions, and creates an array of formatted transaction dictionaries.

- Find_Purchase: Finds a specific purchase by its purchase ID and formats its data for easy use and understanding of purchase object fields. Formatting is not used in the application explicitly. Normal use is to find a purchase by ID and pass a purchase object to Update_Purchase.

- Update_Purchase: Takes a purchase ID and a purchase object, updates the categorization account of the purchase object, then writes the update to QuickBooks through the API. 