### PR TITLE
Hide sign out button from users until the log in.

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
+import Navbar from '@/components/navbar';
 import './globals.css';
-import SignOutButton from '@/components/signout-button';
 
 export const metadata: Metadata = {
   title: 'Transaction Classification Bot',
@@ -15,10 +15,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        <nav className="bg-gray-800 py-4 flex justify-between items-center px-6 sticky top-0 z-50">
-          <div className="text-white">{metadata.title as React.ReactNode}</div>
-          <SignOutButton />
-        </nav>
+        <Navbar />
         {children}
       </body>
     </html>

--- a/frontend/components/navbar.tsx
+++ b/frontend/components/navbar.tsx
@@ -1,0 +1,17 @@
+import SignOutButton from '@/components/signout-button';
+import { getServerSession } from 'next-auth';
+import { options } from '@/app/api/auth/[...nextauth]/options';
+
+const Navbar = async () => {
+  const session = await getServerSession(options);
+  return (
+    <>
+      <nav className="bg-gray-800 py-4 flex justify-between items-center px-6 sticky top-0 z-50">
+        <div className="text-white">Transaction Classification Bot</div>
+        {session && <SignOutButton />}
+      </nav>
+    </>
+  );
+};
+
+export default Navbar;

--- a/frontend/components/signout-button.tsx
+++ b/frontend/components/signout-button.tsx
@@ -1,12 +1,22 @@
 'use client';
-
+import { getSession } from 'next-auth/react';
 import { signOut } from 'next-auth/react';
+import { useState } from 'react';
 
 const SignOutButton = () => {
+  const [buttonClass, setButtonClass] = useState<string>('hidden');
+  // Check if the user is signed in.
+  getSession().then(session => {
+    if (session) {
+      setButtonClass(
+        'text-white bg-red-500 hover:bg-red-600 px-3 py-1.5 rounded transition-colors duration-150'
+      );
+    }
+  });
   return (
     <button
-      className="text-white bg-red-500 hover:bg-red-600 px-3 py-1.5 rounded transition-colors duration-150"
-      onClick={() => signOut({ callbackUrl: 'http://localhost:3000' })}>
+      className={buttonClass}
+      onClick={() => signOut({ callbackUrl: '/' })}>
       Sign Out
     </button>
   );

--- a/frontend/components/signout-button.tsx
+++ b/frontend/components/signout-button.tsx
@@ -1,21 +1,9 @@
 'use client';
-import { getSession } from 'next-auth/react';
 import { signOut } from 'next-auth/react';
-import { useState } from 'react';
-
 const SignOutButton = () => {
-  const [buttonClass, setButtonClass] = useState<string>('hidden');
-  // Check if the user is signed in.
-  getSession().then(session => {
-    if (session) {
-      setButtonClass(
-        'text-white bg-red-500 hover:bg-red-600 px-3 py-1.5 rounded transition-colors duration-150'
-      );
-    }
-  });
   return (
     <button
-      className={buttonClass}
+      className="text-white bg-red-500 hover:bg-red-600 px-3 py-1.5 rounded transition-colors duration-150"
       onClick={() => signOut({ callbackUrl: '/' })}>
       Sign Out
     </button>


### PR DESCRIPTION
Simple fix that adds a use state to the sign out button to hide from users who have not logged in. 
Button is hidden by default and checks the session status before updating to be seen.