### PR TITLE
Bugfixes to the home page and the selection component

### DIFF
--- a/frontend/components/selection.tsx
+++ b/frontend/components/selection.tsx
@@ -3,6 +3,7 @@ import { formatDate } from '@/utils/format-date';
 import { Transaction } from '@/types/Transaction';
 import { get_transactions } from '@/actions/quickbooks';
 import { filterUncategorized } from '@/utils/filter-transactions';
+import { format } from 'date-fns';
 
 export default function SelectionPage({
   unfilteredPurchases,
@@ -40,9 +41,9 @@ export default function SelectionPage({
 
   // Record the default start date and end date.
   const [startDate, setStartDate] = useState<string>(
-    backTwoYears.toLocaleDateString()
+    format(backTwoYears, 'yyyy-MM-dd')
   );
-  const [endDate, setEndDate] = useState<string>(today.toLocaleDateString());
+  const [endDate, setEndDate] = useState<string>(format(today, 'yyyy-MM-dd'));
 
   // Fetch the transactions from the backend when date is updated.
   const handleDateUpdate = async () => {

--- a/frontend/components/selection.tsx
+++ b/frontend/components/selection.tsx
@@ -90,7 +90,8 @@ export default function SelectionPage({
   const handleStartDateChange = (event: string) => {
     if (
       new Date(event) < new Date(endDate) &&
-      new Date(event) > new Date('2000-01-01')
+      new Date(event) > new Date('2000-01-01') &&
+      new Date(event) < new Date()
     ) {
       setStartDate(event);
     }
@@ -101,7 +102,8 @@ export default function SelectionPage({
   const handleEndDateChange = (event: string) => {
     if (
       new Date(event) > new Date(startDate) &&
-      new Date(event) > new Date('2000-01-01')
+      new Date(event) > new Date('2000-01-01') &&
+      new Date(event) < new Date()
     ) {
       setEndDate(event);
     }

--- a/frontend/components/selection.tsx
+++ b/frontend/components/selection.tsx
@@ -44,11 +44,6 @@ export default function SelectionPage({
   );
   const [endDate, setEndDate] = useState<string>(today.toLocaleDateString());
 
-  // Define the updated purchase table.
-  const [updatedPurchaseTable, setUpdatedPurchaseTable] = useState<
-    JSX.Element | JSX.Element[]
-  >([]);
-
   // Fetch the transactions from the backend when date is updated.
   const handleDateUpdate = async () => {
     try {
@@ -90,15 +85,23 @@ export default function SelectionPage({
   };
 
   // Update the start date if the start date is before the end date.
+  // Also check that the start date is in the past but after 2000.
   const handleStartDateChange = (event: string) => {
-    if (new Date(event) < new Date(endDate)) {
+    if (
+      new Date(event) < new Date(endDate) &&
+      new Date(event) > new Date('2000-01-01')
+    ) {
       setStartDate(event);
     }
   };
 
   // Update the end date if the end date is after the start date.
+  // Also check that the end date is in the past but after 2000.
   const handleEndDateChange = (event: string) => {
-    if (new Date(event) > new Date(startDate)) {
+    if (
+      new Date(event) > new Date(startDate) &&
+      new Date(event) > new Date('2000-01-01')
+    ) {
       setEndDate(event);
     }
   };
@@ -140,11 +143,21 @@ export default function SelectionPage({
 
   const mapPurchases = (purchases: Transaction[]) => {
     // If the transactions are still loading, display a loading message.
-    if (purchases.length === 0 && madeDateSearch === false) {
+    if (unfilteredPurchases.length === 0 && madeDateSearch === false) {
       return (
         <tr>
           <td colSpan={6} className="text-center text-lg py-4">
             Loading . . .
+          </td>
+        </tr>
+      );
+    }
+    // If the transactions have loaded and there are no transactions, display a message.
+    if (unfilteredPurchases.length !== 0 && purchases.length === 0) {
+      return (
+        <tr>
+          <td colSpan={6} className="text-center text-lg py-4">
+            No transactions found.
           </td>
         </tr>
       );


### PR DESCRIPTION
Small bug fix to prevent an issue with the date selection method on different browsers.

Improvement on date checks to also ensure dates are in the 2000's and not in the future. This is in addition to an existing check that the start is before the end.

Added a change for the case of no loaded transactions. When the loading finishes, if the initial set of transactions queried is empty, the loading message is replaced with a message that no transactions were found.