### PR TITLE
Play Wright Tests to QA test implemented features

### DIFF
--- a/playwright-tests/.gitignore
+++ b/playwright-tests/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+
+package-lock.json
+tests/config.ts

--- a/playwright-tests/package.json
+++ b/playwright-tests/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "playwright-tests",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "test": "npx playwright test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "devDependencies": {
+    "@playwright/test": "^1.44.0",
+    "@types/node": "^20.12.12"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.5"
+  }
+}

--- a/playwright-tests/playwright.config.ts
+++ b/playwright-tests/playwright.config.ts
@@ -1,0 +1,81 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  timeout: 30000,
+  testDir: './tests',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    // baseURL: 'http://127.0.0.1:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        headless: false,
+      },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'npm run start',
+  //   url: 'http://127.0.0.1:3000',
+  //   reuseExistingServer: !process.env.CI,
+  // },
+});

--- a/playwright-tests/playwright.config.ts
+++ b/playwright-tests/playwright.config.ts
@@ -41,15 +41,15 @@ export default defineConfig({
       },
     },
 
-    {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
-    },
+    // {
+    //   name: 'firefox',
+    //   use: { ...devices['Desktop Firefox'] },
+    // },
 
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
-    },
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] },
+    // },
 
     /* Test against mobile viewports. */
     // {

--- a/playwright-tests/tests/auth.json
+++ b/playwright-tests/tests/auth.json
@@ -1,0 +1,41 @@
+{
+    "cookies": [
+        {
+            "name": "__Secure-next-auth.state",
+            "value": ""
+        },
+        {
+            "name": "__Secure-next-auth.session-token",
+            "value": "eyJhbGciOiJkaXIiLCJlbmMiOiJBMjU2R0NNIn0..LSpj8L3nnQ4Uc1vB.Y1Bukigf5OEWu_T-8ZMuKwQoXifvdktuQHhSBB2zmGJ7CHCUOoXwZYjFt7OxeFvtL3JN0_yH2FtIs0wNBSEyNeBuuICd3geHtPEfjlMudZtRB1q864ZBI3sUzHR1JmR1XqC4IhBdyS8xElCOV7i3AK_UP_-PPf2ICOJ1BOBG3daZ6gxDo4kTnXMNBL4hwHDqhWxRHDoBPID1EKYj541vANMFMbgF381oOXmvrypT3TgDP5sd2CpWvpfwiPsl4yG8Aat5KSf3sRsL2O6tiBGIAiimty6zk2wdPbbOhfZLhy-UDVNY5J_-GWYG2np99386WXnFlG6R8HW2Vrcq7jSRCKpTvEGdaNjhCF8ZPPizVRmELxpIx42i17QAVm3bcwr7_haJUlVYab1ilCJb22LwyMTtvvIUSQSnqkEOKHk6Nv6DXFIgj_AfjWP_NpZA03YDj58q70pbOknJQfcc9Bi6bZmm5sJO8g3MJiZX7K8Mxhz6ZhyMxkcxsmEIKFvzLo0FAqkhIzCg8zVl6OtrP8jDthf2wGZ3ZBRZ8lLzbl9e8STdRwqrcqOjM-lHL_yPA-Ron04hyVIHTtX5TIy3TuhUSxBGGmRhSJHniNQxK-EJHeRiu9bwG9IxaMtKBGA0fnQeV_fImgrkX8wZqgGYEYCnbRoScz74fS0sckjJ2Xw8pvAD3qLnLa-HVina3ILzyYSGilWS0BZHYgjpvuk8fqfln7ZuHQh-e-9HmLZhyUAXDPLdUj-ENMC0vhR8hB1PbZs0qyo6JmL_5FzjinrPOrGFurHJpFoOOqNCKQNRIentBzQp60822p1Av5jXtmqkIUY81ETr7xqyhE2vEfsg4_jAYFCPbZHQB9oLggTTEEsg0FkAEviFCJzu4mSuBnk6wRTCTbqNTY2JtlDytIvxzoS9jNauQVIRjS_ze6ry4RNqkFGdcSkj49fcZqeLRgBqprwP9mwj5mJ3onyKn-IosbDWdLF6KT6x2j7FJddgTgwOn8C9wWkVie9MRXdx-HPZdaRQ2PACcKJeQoKD8RQ-EL-UeZSmpCFvcSjhOgepW0lJfhgwUx7YT7WpPTX12-q6SPT8QOtDVihfXjYoresr65go1bKRwYkJppSUb27uPbthWqlE0oqhN8vvH-mW-Ia870kJRCReSZCGM8w95maME5cJ-ZXxCyWdZAkem5wrGuNHIq1CUtBf1UJvv2C6Or_r4REAuS8rW2R-8TsrWmxF7WwN2Vdb7se0ZJEuqfvEFRu-kotwoioADoMBt36L4QacGI0v7dZ6oBOwUnbuK2LsCm6kgcQhA2YbROBVqzj1AzZGf05GkyBLG4r59lSDCKyREYyGuZYv0Jvar2uL5lEI4k47j_V2WhPkE07oKE6eMUqf7N8vFKVr_ydDe7dffmpcm2a4toXce5KTzLm1ESKTn1eaS33bOVNLQjix35jl1dp1MI3Z7Rfn0EWKKcGTCsfzwym5ip_ZMCqagMd8DEs-NUplAj5rbUX622nLcAtz8F1uLQe5okR9zv6vGUsFCIwT0p7g6CMNwzISf9EDA0asbxQ3qhNKIL3dIr-hsvt33z0sjX1uxiQe1PVKMEk8J29XYO4EZqcSv5CDEoi3i7kgsQ2sGed-BMB0PkdpS3adTgmwo2Y2vV7rYLCHwgcodbRdzjrHkHZUcFzfgDbXLvZ2UL8WLAXx3T-_Hnqu7ktyKXFsGAPJfFeAjKjPJnOnmWbeakWqnnsHypd80lqRZK4IkJLta8PvkECxz6IByH8zWLPUbGwCeOj13nzOMA0YooKSWSfIZDMbhtcUnQ.ygGumyPAmszSeB6g388tzg"
+        },
+        {
+            "name": "__Secure-next-auth.pkce.code_verifier",
+            "value": ""
+        },
+        {
+            "name": "__Secure-next-auth.callback-url",
+            "value": "https%3A%2F%2Ftransaction-classification-bot.vercel.app%2Fhome"
+        },
+        {
+            "name": "__Host-next-auth.csrf-token",
+            "value": "0e17314ffbdddcbc0a3c7798caccc047659b4b780bbf9f2377d337afd1159787%7Cb712dc5d3389f1d7e741bad605d291f829090a1d2175b9c3421ce01194491f59"
+        }
+    ],
+    "origins": [
+        {
+            "origin": "https://transaction-classification-bot.vercel.app",
+            "localStorage": [
+                {
+                    "name": "nextauth.message",
+                    "value": {
+                        "event": "session",
+                        "data": {
+                            "trigger": "getSession"
+                        },
+                        "timestamp": 1716404840
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/playwright-tests/tests/authhelper.ts
+++ b/playwright-tests/tests/authhelper.ts
@@ -1,0 +1,52 @@
+import { Page } from 'playwright';
+
+interface Config {
+  USER_EMAIL: string;
+  USER_PASSWORD: string;
+}
+
+async function authenticate(page: Page, config: Config): Promise<void> {
+  // Navigate to the login page
+  await page.goto('https://transaction-classification-bot.vercel.app/home');
+
+  // Click on the login button
+  const loginButton = await page.$('text=Intuit Sign-In');
+  if (!loginButton) {
+    throw new Error('Login button not found');
+  }
+  await loginButton.click();
+
+  // Fill in the email
+  await page.fill(
+    'input[data-testid="IdentifierFirstInternationalUserIdInput"]',
+    config.USER_EMAIL
+  );
+
+  // Click on the "sign in" button
+  await page.click('span.Button-label-e0ecc32');
+
+  // Fill in the password
+  await page.fill(
+    'input[data-testid="currentPasswordInput"]',
+    config.USER_PASSWORD
+  );
+
+  // Click on the continue button
+  await page.click('button[data-testid="passwordVerificationContinueButton"]');
+
+  // Click on the dropdown menu
+  await page.click('.DropdownTypeahead-iconBox-8f787c3');
+
+  // Select the desired option
+  await page.click('.Menu-menu-item-wrapper-d1d881d');
+
+  // Click on the "Next" button
+  await page.click('text=Next');
+
+  // Wait for the redirection to the home page
+  await page.waitForURL(
+    'https://transaction-classification-bot.vercel.app/home'
+  );
+}
+
+export { authenticate };

--- a/playwright-tests/tests/config.ts
+++ b/playwright-tests/tests/config.ts
@@ -1,0 +1,6 @@
+export const config = {
+  BASE_URL: 'localhost:3000',
+  USER_FILE: 'playwright-tests/tests/auth.json',
+  USER_EMAIL: 'replace',
+  USER_PASSWORD: 'replace',
+};

--- a/playwright-tests/tests/homepage.spec.ts
+++ b/playwright-tests/tests/homepage.spec.ts
@@ -1,0 +1,135 @@
+import { test, expect } from '@playwright/test';
+import { config } from './config';
+import { authenticate } from './authhelper';
+
+// For the test, we will check if the Uncategorized Expense category is present in the table rows after confirming these transactions to load on intuit sandbox.
+test('Check for Uncategorized Expense category in table rows', async ({
+  page,
+}) => {
+  const info = {
+    USER_EMAIL: config.USER_EMAIL,
+    USER_PASSWORD: config.USER_PASSWORD,
+  };
+  await authenticate(page, info);
+
+  // Locate all <tr> elements
+  const trElements = await page.$$('tr'); // Adjust the selector as needed
+
+  // Iterate over each <tr> element
+  for (const trElement of trElements) {
+    // Get the text content of the <tr> element
+    const trText = await trElement.innerText();
+
+    // Check if the text content contains the category "Uncategorized Expense"
+    const containsUncategorized = trText.includes('Uncategorized Expense');
+
+    // Use the result as needed
+    if (containsUncategorized) {
+      expect(containsUncategorized).toBeTruthy();
+    }
+  }
+});
+
+// Transactions can be selected with clear highlighting of selected transactions.
+test('Check for clear highlighting of selected transactions', async ({
+  page,
+}) => {
+  const info = {
+    USER_EMAIL: config.USER_EMAIL,
+    USER_PASSWORD: config.USER_PASSWORD,
+  };
+  await authenticate(page, info);
+  await page.waitForTimeout(3000);
+  await page.waitForSelector('td');
+
+  await page.locator('td').first().click();
+  const isSelected = await page.evaluate(() => {
+    const trElement = document.querySelector('td:first-child').closest('tr');
+    return trElement.classList.contains('bg-blue-100');
+  });
+
+  expect(isSelected).toBeTruthy();
+});
+
+// Transactions can be mass selected with clear highlighting of all selected transactions.
+test('Check for clear highlighting of all selected transactions', async ({
+  page,
+}) => {
+  const info = {
+    USER_EMAIL: config.USER_EMAIL,
+    USER_PASSWORD: config.USER_PASSWORD,
+  };
+  await authenticate(page, info);
+  await page.waitForTimeout(3000);
+  await page.click('th input[type="checkbox"]');
+
+  const areAllSelected = await page.evaluate(() => {
+    const trElements = document.querySelectorAll('#purchaseTable tr');
+    let allSelected = true;
+    trElements.forEach(trElement => {
+      if (!trElement.classList.contains('bg-blue-100')) {
+        allSelected = false;
+      }
+    });
+    return allSelected;
+  });
+
+  expect(areAllSelected).toBeTruthy();
+});
+
+// Transactions can be filtered by date
+test('Filter by date', async ({ page }) => {
+  const info = {
+    USER_EMAIL: config.USER_EMAIL,
+    USER_PASSWORD: config.USER_PASSWORD,
+  };
+  await authenticate(page, info);
+  await page.waitForTimeout(3000);
+  await page.click('th button:has-text("Date")');
+  const areDatesSortedAscending = await page.evaluate(() => {
+    const dateCells = Array.from(
+      document.querySelectorAll('#purchaseTable td:nth-child(2)')
+    );
+    const dates = dateCells.map(cell => new Date(cell.textContent.trim()));
+    for (let i = 1; i < dates.length; i++) {
+      if (dates[i] < dates[i - 1]) {
+        return false;
+      }
+    }
+    return true;
+  });
+  await page.pause();
+
+  expect(areDatesSortedAscending).toBeTruthy();
+});
+
+// Transactions can be filtered by total
+test('Filter by total', async ({ page }) => {
+  const info = {
+    USER_EMAIL: config.USER_EMAIL,
+    USER_PASSWORD: config.USER_PASSWORD,
+  };
+  await authenticate(page, info);
+  await page.waitForTimeout(3000);
+  await page.click('th button:has-text("Total")');
+  const isTotalSortedAscending = await page.evaluate(() => {
+    const totalCells = Array.from(
+      document.querySelectorAll('#purchaseTable td:nth-child(6)')
+    );
+    const total = totalCells.map(cell => {
+      const totalText = cell.textContent.trim();
+      // Remove non-numeric characters and convert to number
+      const total = parseFloat(totalText.replace(/[^0-9.-]+/g, ''));
+      return total;
+    });
+
+    for (let i = 1; i < total.length; i++) {
+      if (total[i] < total[i - 1]) {
+        return false;
+      }
+    }
+    return true;
+  });
+
+  expect(isTotalSortedAscending).toBeTruthy();
+});

--- a/playwright-tests/tests/landingpage.spec.ts
+++ b/playwright-tests/tests/landingpage.spec.ts
@@ -75,3 +75,29 @@ test('User sign-in functionality', async ({ page }) => {
 
   // this will lead to phone or email verification which we will consider has passed the login test
 });
+
+test('User redirect to login page when not logged in', async ({ page }) => {
+  // Navigate to the home page
+  await page.goto('https://transaction-classification-bot.vercel.app/home');
+  await page.waitForURL(
+    'https://transaction-classification-bot.vercel.app/api/auth/signin'
+  );
+
+  // Check if the user is redirected to the login page
+  const signInButton = await page.$('text=Intuit Sign-In');
+  expect(signInButton).toBeTruthy();
+});
+
+test('User remains on home page when already logged in', async ({ page }) => {
+  // Navigate to the home page
+  await page.goto('https://transaction-classification-bot.vercel.app/home');
+
+  // Check if specific elements unique to the home page are present
+  const homePageElement = await page.$('text=My Expenses');
+  expect(homePageElement).toBeTruthy();
+
+  // Check if the URL remains on the home page
+  expect(page.url()).toBe(
+    'https://transaction-classification-bot.vercel.app/home'
+  );
+});

--- a/playwright-tests/tests/landingpage.spec.ts
+++ b/playwright-tests/tests/landingpage.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from '@playwright/test';
+import { config } from './config';
+
+test('landing page', async ({ page }) => {
+  await page.goto('https://transaction-classification-bot.vercel.app/');
+
+  // Check if the "Intuit Sign-In" button is present
+  const signInButton = await page.$('text=Intuit Sign-In');
+  if (signInButton) {
+    const signInButtonText = await signInButton.textContent();
+    expect(signInButtonText).toBe('Intuit Sign-In');
+  } else {
+    // Check for the "Proceed to Home Page" button if "Intuit Sign-In" is not found
+    const proceedButton = await page.$('text=Proceed to Home Page');
+    expect(proceedButton).toBeTruthy();
+
+    if (proceedButton) {
+      const proceedButtonText = await proceedButton.textContent();
+      expect(proceedButtonText).toBe('Proceed to Home Page');
+    }
+  }
+});
+
+test('User sign-in functionality', async ({ page }) => {
+  // Define mock API responses
+  const mockSignInSuccessResponse = {
+    status: 'success',
+    data: {
+      userId: '123456',
+      accessToken: 'mock-access-token',
+      refreshToken: 'mock-refresh-token',
+    },
+  };
+
+  const mockSignInErrorResponse = {
+    status: 'error',
+    error: 'invalid_credentials',
+    message: 'Invalid username or password',
+  };
+
+  // Intercept API requests for sign-in endpoint
+  await page.route(
+    'https://transaction-classification-bot.vercel.app/api/auth/signin',
+    route => {
+      // Respond with mock success response for successful sign-in
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockSignInSuccessResponse),
+      });
+    }
+  );
+
+  // Navigate to signin page
+  await page.goto('https://accounts.intuit.com/app/sign-in');
+
+  // Simulate user interaction for email
+  console.log('User email:', process.env.USER_EMAIL);
+  await page.fill(
+    'input[data-testid="IdentifierFirstIdentifierInput"]',
+    config.USER_EMAIL
+  );
+
+  // Click on the "sign in" button
+  await page.click('span.Button-label-e0ecc32');
+
+  // Simulate user interaction for password
+  await page.fill(
+    'input[data-testid="currentPasswordInput"]',
+    config.USER_PASSWORD
+  );
+
+  // click on the continue button
+  await page.click('button[data-testid="passwordVerificationContinueButton"]');
+
+  // this will lead to phone or email verification which we will consider has passed the login test
+});

--- a/playwright-tests/tests/landingpage.spec.ts
+++ b/playwright-tests/tests/landingpage.spec.ts
@@ -1,7 +1,8 @@
 import { test, expect } from '@playwright/test';
 import { config } from './config';
+import { authenticate } from './authhelper';
 
-test('landing page', async ({ page }) => {
+test('landing page and logout button', async ({ page }) => {
   await page.goto('https://transaction-classification-bot.vercel.app/');
 
   // Check if the "Intuit Sign-In" button is present
@@ -9,6 +10,10 @@ test('landing page', async ({ page }) => {
   if (signInButton) {
     const signInButtonText = await signInButton.textContent();
     expect(signInButtonText).toBe('Intuit Sign-In');
+
+    // When not logged in, there should be no logout button
+    const logoutButton = await page.$('text=Logout');
+    expect(logoutButton).toBeFalsy();
   } else {
     // Check for the "Proceed to Home Page" button if "Intuit Sign-In" is not found
     const proceedButton = await page.$('text=Proceed to Home Page');
@@ -18,6 +23,9 @@ test('landing page', async ({ page }) => {
       const proceedButtonText = await proceedButton.textContent();
       expect(proceedButtonText).toBe('Proceed to Home Page');
     }
+    // Check for the logout button if the user is already logged in
+    const logoutButton = await page.$('text=Sign Out');
+    expect(logoutButton).toBeTruthy();
   }
 });
 
@@ -72,7 +80,6 @@ test('User sign-in functionality', async ({ page }) => {
 
   // click on the continue button
   await page.click('button[data-testid="passwordVerificationContinueButton"]');
-
   // this will lead to phone or email verification which we will consider has passed the login test
 });
 
@@ -80,7 +87,7 @@ test('User redirect to login page when not logged in', async ({ page }) => {
   // Navigate to the home page
   await page.goto('https://transaction-classification-bot.vercel.app/home');
   await page.waitForURL(
-    'https://transaction-classification-bot.vercel.app/api/auth/signin'
+    'https://transaction-classification-bot.vercel.app/api/auth/signin?callbackUrl=%2Fhome'
   );
 
   // Check if the user is redirected to the login page
@@ -88,16 +95,51 @@ test('User redirect to login page when not logged in', async ({ page }) => {
   expect(signInButton).toBeTruthy();
 });
 
-test('User remains on home page when already logged in', async ({ page }) => {
-  // Navigate to the home page
-  await page.goto('https://transaction-classification-bot.vercel.app/home');
+// TEST COMMENTED OUT DUE TO AUTHENTICATED STATE NOT PERSISTING ACROSS TESTS
+// test.use({ storageState: process.env.USER_AUTH });
 
-  // Check if specific elements unique to the home page are present
-  const homePageElement = await page.$('text=My Expenses');
-  expect(homePageElement).toBeTruthy();
+// test('User remains on home page when already logged in', async ({ page }) => {
+//     // Navigate to the home page
+//     await page.goto('https://transaction-classification-bot.vercel.app/home');
 
-  // Check if the URL remains on the home page
-  expect(page.url()).toBe(
-    'https://transaction-classification-bot.vercel.app/home'
+//     // Check if specific elements unique to the home page are present
+//     const homePageElement = await page.$('text=My Expenses');
+//     expect(homePageElement).toBeTruthy();
+
+//     // Check if the URL remains on the home page
+//     expect(page.url()).toBe(
+//         'https://transaction-classification-bot.vercel.app/home'
+//     );
+// });
+
+// COMMENTED OUT DUE TO AUTHENTICATED STATE NOT PERSISTING ACROSS TESTS
+//test.use({ storageState: process.env.USER_AUTH });
+
+// TEST REQUIRES USER TO PUT IN A await page.pause() COMMAND TO MANUALLY VERIFY PHONE / EMAIL ONE TIME BEFORE THE AUTHENTICATION SKIPS 2FA CHECK.
+test('logged in user clicks logout button', async ({ page }) => {
+  const info = {
+    USER_EMAIL: config.USER_EMAIL,
+    USER_PASSWORD: config.USER_PASSWORD,
+  };
+  await authenticate(page, info);
+
+  // Find and click on the logout button
+  const logoutButton = await page.$('text=Sign Out');
+  expect(logoutButton).toBeTruthy();
+  await logoutButton.click();
+
+  // Check if the user is redirected to the login page
+  await page.waitForURL(
+    'https://transaction-classification-bot.vercel.app/api/auth/signin?callbackUrl=%2F'
   );
+});
+
+// TEST REQUIRES USER TO PUT IN A await page.pause() COMMAND TO MANUALLY VERIFY PHONE / EMAIL ONE TIME BEFORE THE AUTHENTICATION SKIPS 2FA CHECK.
+
+test('User signs in and redirects to home in deployed', async ({ page }) => {
+  const info = {
+    USER_EMAIL: config.USER_EMAIL,
+    USER_PASSWORD: config.USER_PASSWORD,
+  };
+  await authenticate(page, info);
 });

--- a/playwright-tests/tsconfig.json
+++ b/playwright-tests/tsconfig.json
@@ -1,0 +1,7 @@
+{
+    "compilerOptions": {
+        "types": [
+            "node"
+        ]
+    }
+}


### PR DESCRIPTION
Created qa tests to test out various features that have been sent to me.
These tests run using my account info so would need to replace the config.ts file within the playwright-tests/tests folder with own intuit credentials.

For the play wright tests to work specifically for my case, I ran the playwright tests and added the line 
`await page.pause()` during the login authentication to complete the one time phone/email verification.
When incorporating github actions, will be commenting out all tests that require user login.

use npm install --save-dev @playwright/test and npm run test to test out the playwright tests.
