### PR TITLE
Implemented confidence bar with hover description.

### DIFF
--- a/frontend/components/data-table/columns.tsx
+++ b/frontend/components/data-table/columns.tsx
@@ -1,5 +1,6 @@
 import { Column, ColumnDef, Row, Table } from '@tanstack/react-table';
 import { Checkbox } from '@/components/ui/checkbox';
+import { ConfidenceBar } from '@/components/ui/confidence-bar';
 import { CategorizedTransaction, Transaction } from '@/types/Transaction';
 import { format } from 'date-fns';
 import { Button } from '../ui/button';
@@ -216,20 +217,52 @@ export const reviewColumns = (
     accessorKey: 'confidence',
     header: 'Confidence',
     cell: ({ row }) => {
-      let confidence = 0;
+      // Define confidence bar formatting for each section.
+      let barOneFormatting = 'w-8 h-6 m-1 bg-gray-200 rounded-l-lg';
+      let barTwoFormatting = 'w-8 h-6 m-1 bg-gray-200';
+      let barThreeFormatting = 'w-8 h-6 m-1 bg-gray-200 rounded-r-lg';
+      let confidenceValue = 0;
       const categories: ClassifiedCategory[] = row.getValue('categories');
       if (categories.length > 0) {
+        confidenceValue = 1;
+        // If a predicted category is found, change the first bar to green.
+        barOneFormatting = 'w-8 h-6 m-1 bg-green-400 rounded-l-lg';
         for (const category of categories) {
-          if (category.classifiedBy === 'Fuzzy or Exact Match by Fuse') {
-            confidence = 3;
-            break;
-          }
           if (category.classifiedBy === 'Database Lookup') {
-            confidence = 2;
+            // If the category is classified by database lookup, change the second bar to green.
+            barTwoFormatting = 'w-8 h-6 m-1 bg-green-400';
+            confidenceValue = 2;
+          }
+          if (category.classifiedBy === 'Fuzzy or Exact Match by Fuse') {
+            // If the category is classified by fuze match, change the second and third bars to green.
+            barTwoFormatting = 'w-8 h-6 m-1 bg-green-400';
+            barThreeFormatting = 'w-8 h-6 m-1 green-400 rounded-r-lg';
+            confidenceValue = 3;
+            break;
           }
         }
       }
-      return confidence;
+      let hoverText = '';
+      if (confidenceValue == 0) {
+        hoverText = 'No category results found.';
+      }
+      if (confidenceValue == 1) {
+        hoverText = 'Results found by LLM prediction.';
+      }
+      if (confidenceValue == 2) {
+        hoverText = 'Results found by database check.';
+      }
+      if (confidenceValue == 3) {
+        hoverText = 'Results found by name matching.';
+      }
+      return (
+        <ConfidenceBar
+          barOne={barOneFormatting}
+          barTwo={barTwoFormatting}
+          barThree={barThreeFormatting}
+          hoverText={hoverText}
+        />
+      );
     },
   },
 ];

--- a/frontend/components/data-table/columns.tsx
+++ b/frontend/components/data-table/columns.tsx
@@ -4,7 +4,7 @@ import { CategorizedTransaction, Transaction } from '@/types/Transaction';
 import { format } from 'date-fns';
 import { Button } from '../ui/button';
 import { ArrowUpDown } from 'lucide-react';
-import { Category } from '@/types/Category';
+import { Category, ClassifiedCategory } from '@/types/Category';
 
 // Define button for a sortable header
 const sortableHeader = (
@@ -178,6 +178,7 @@ export const selectionColumns: ColumnDef<Transaction>[] = [
 
 export const reviewColumns = (
   selectedCategories: Record<string, string>,
+  categorizedResults: Record<string, Category[]>,
   handleCategoryChange: (transaction_ID: string, category: string) => void
 ): ColumnDef<CategorizedTransaction>[] => [
   commonColumns[0],
@@ -210,4 +211,25 @@ export const reviewColumns = (
     },
   },
   commonColumns[5],
+  // Confidence column
+  {
+    accessorKey: 'confidence',
+    header: 'Confidence',
+    cell: ({ row }) => {
+      let confidence = 0;
+      const categories: ClassifiedCategory[] = row.getValue('categories');
+      if (categories.length > 0) {
+        for (const category of categories) {
+          if (category.classifiedBy === 'Fuzzy or Exact Match by Fuse') {
+            confidence = 3;
+            break;
+          }
+          if (category.classifiedBy === 'Database Lookup') {
+            confidence = 2;
+          }
+        }
+      }
+      return confidence;
+    },
+  },
 ];

--- a/frontend/components/data-table/review-table.tsx
+++ b/frontend/components/data-table/review-table.tsx
@@ -24,17 +24,20 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { CategorizedTransaction, Transaction } from '@/types/Transaction';
+import { ClassifiedCategory } from '@/types/Category';
 import { reviewColumns } from './columns';
 
 export function ReviewTable({
   categorizedTransactions,
   selectedCategories,
+  categorizedResults,
   handleCategoryChange,
   handleSave,
   isSaving,
 }: {
   categorizedTransactions: CategorizedTransaction[];
   selectedCategories: Record<string, string>;
+  categorizedResults: Record<string, ClassifiedCategory[]>;
   handleCategoryChange: (transaction_ID: string, category: string) => void;
   handleSave: (selectedRows: CategorizedTransaction[]) => void;
   isSaving: boolean;
@@ -49,7 +52,11 @@ export function ReviewTable({
 
   const table = useReactTable({
     data: categorizedTransactions,
-    columns: reviewColumns(selectedCategories, handleCategoryChange),
+    columns: reviewColumns(
+      selectedCategories,
+      categorizedResults,
+      handleCategoryChange
+    ),
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,
     getCoreRowModel: getCoreRowModel(),

--- a/frontend/components/home/review.tsx
+++ b/frontend/components/home/review.tsx
@@ -83,6 +83,7 @@ export default function ReviewPage({
       <ReviewTable
         categorizedTransactions={categorizedTransactions}
         selectedCategories={selectedCategories}
+        categorizedResults={categorizationResults}
         handleCategoryChange={handleCategoryChange}
         handleSave={handleSave}
         isSaving={isSaving}

--- a/frontend/components/ui/confidence-bar.tsx
+++ b/frontend/components/ui/confidence-bar.tsx
@@ -1,0 +1,27 @@
+'use client';
+import { useState } from 'react';
+
+export function ConfidenceBar({
+  barOne,
+  barTwo,
+  barThree,
+  hoverText,
+}: {
+  barOne: string;
+  barTwo: string;
+  barThree: string;
+  hoverText: string;
+}) {
+  return (
+    <div className="relative flex w-fit border-2 mx-2 border-blue-300 rounded-lg ">
+      <div className={barOne}></div>
+      <div className={barTwo}></div>
+      <div className={barThree}></div>
+      <div className="opacity-0 hover:opacity-100 duration-300 absolute w-32 inset-0 flex justify-center -translate-x-1">
+        <div className="bg-gray-400 bg-opacity-90 h-fit text-sm text-center rounded-lg p-1 -translate-y-2">
+          {hoverText}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Updated the code so that the information on how the classification was made is passed down to the table creation layer, in addition to the existing transaction information.

Using the classification method, the tailwind rules for the confidence bar visuals are created, with 0, 1, 2, or 3 colored segments for the possible classification methods. (Presently the exact and fuzzy match return the same indicator).
0 - No classification
1 - LLM classification
2 - Database classification
3 - Fuse match classification.

At the same time the visuals rules are defined, the appropriate line of text is also defined that will display above the confidence bar when the user hovers over it.